### PR TITLE
Automated cherry pick of #93: update DefaultCalicoVersion to 3.12.1

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	CalicoKubeControllers          = "calico-kube-controllers"
 	CalicoNode                     = "calico-node"
 	CalicoCNI                      = "calico-cni"
-	DefaultCalicoVersion           = "v3.7.2"
+	DefaultCalicoVersion           = "v3.12.1"
 	Loki                           = "loki"
 	DefaultLokiVersion             = "v1.2.0"
 	Promtail                       = "promtail"


### PR DESCRIPTION
Cherry pick of #93 on release/3.3.

#93: update DefaultCalicoVersion to 3.12.1