### PR TITLE
 修复 keepalived master state bug

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -31,7 +31,7 @@ const (
 	DefaultPromtailVersion         = DefaultLokiVersion
 	Grafana                        = "grafana"
 	DefaultGrafanaVersion          = "6.5.2"
-	DefaultKeepalivedVersionTag    = "v2.0.22"
+	DefaultKeepalivedVersionTag    = "v2.0.23"
 	// mirror of kiwigrid/k8s-sidecar:0.1.20
 	K8sSidecar               = "k8s-sidecar"
 	DefaultK8sSidecarVersion = "0.1.20"


### PR DESCRIPTION
* 修改 keepalived 验证密码、route id 算法，防止同一局域网里两个集群相互干扰
* 修改 部分 keepalived env 选项，解决「 高可用keepalived配置noprempt和state不应同时存在」的问题