### PR TITLE
 高可用部署主备选取应将kube-apiserver是否工作考虑进去

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -31,7 +31,7 @@ const (
 	DefaultPromtailVersion         = DefaultLokiVersion
 	Grafana                        = "grafana"
 	DefaultGrafanaVersion          = "6.5.2"
-	DefaultKeepalivedVersionTag    = "v2.0.23"
+	DefaultKeepalivedVersionTag    = "v2.0.24"
 	// mirror of kiwigrid/k8s-sidecar:0.1.20
 	K8sSidecar               = "k8s-sidecar"
 	DefaultK8sSidecarVersion = "0.1.20"

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -697,6 +697,11 @@ func (d *initData) OperatorVersion() string {
 	return d.operatorVersion
 }
 
+// GetNodeIP returns current node ip for init mode
+func (d *initData) GetNodeIP() string {
+	return d.nodeIP
+}
+
 func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i *initData) error {
 	joinControlPlaneCommand, err := occmdutil.GetJoinControlPlaneCommand(adminKubeConfigPath, token, i.certificateKey, i.skipTokenPrint, i.skipCertificateKeyPrint)
 	if err != nil {

--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -558,6 +558,11 @@ func (j *joinData) OutputWriter() io.Writer {
 	return j.outputWriter
 }
 
+// GetNodeIP returns current node ip for join mode
+func (j *joinData) GetNodeIP() string {
+	return j.nodeIP
+}
+
 // fetchInitConfigurationFromJoinConfiguration retrieves the init configuration from a join configuration, performing the discovery
 func fetchInitConfigurationFromJoinConfiguration(cfg *apiv1.JoinConfiguration, tlsBootstrapCfg *clientcmdapi.Config) (*apiv1.InitConfiguration, error) {
 	// Retrieves the kubeadm configuration

--- a/pkg/phases/init/data.go
+++ b/pkg/phases/init/data.go
@@ -26,4 +26,5 @@ type InitData interface {
 	AddonCalicoIpAutodetectionMethod() string
 	GetHighAvailabilityVIP() string
 	GetKeepalivedVersionTag() string
+	GetNodeIP() string
 }

--- a/pkg/phases/join/data.go
+++ b/pkg/phases/join/data.go
@@ -14,4 +14,5 @@ type JoinData interface {
 	OnecloudJoinCfg() *apiv1.JoinConfiguration
 	GetHighAvailabilityVIP() string
 	GetKeepalivedVersionTag() string
+	GetNodeIP() string
 }


### PR DESCRIPTION
bug: https://bug.yunion.io/zentao/bug-view-5201.html
ocadm 创建 keepalived 集群 时，对 container 传入本机 NODE_IP，以便检验本机的 kube-apiserver 存活状态。