### PR TITLE
Automated cherry pick of #158: fix(cluster): set OS_PROJECT_DOMAIN of cluster auth info

### DIFF
--- a/pkg/phases/cluster/cluster.go
+++ b/pkg/phases/cluster/cluster.go
@@ -528,6 +528,7 @@ func GetClusterRCAdmin(data *clusterData) (string, error) {
 		`export OS_AUTH_URL=%s
 export OS_USERNAME=sysadmin
 export OS_PASSWORD=%s
+export OS_PROJECT_DOMAIN=default
 export OS_PROJECT_NAME=system
 export YUNION_INSECURE=true
 export OS_REGION_NAME=%s


### PR DESCRIPTION
Cherry pick of #158 on release/3.6.

#158: fix(cluster): set OS_PROJECT_DOMAIN of cluster auth info