### PR TITLE
Automated cherry pick of #161: feat(build): 增加arm 下编译 ocadm deb 的步骤(make deb)； 统一跨平台metrics-server 的 tag 名称；升级 k8s-sidecar 到 0.1.275

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ GTAGS
 
 # packages
 *.rpm
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GO111MODULE:=on
 export GOPROXY:=direct
 
 VERSION_PKG := yunion.io/x/pkg/util/version
-
+ROOT_DIR := $(CURDIR)
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 
 ifndef GIT_BRANCH
@@ -41,4 +41,6 @@ mod:
 	go mod tidy
 	go mod vendor -v
 
+deb: clean
+	DEBUG=$(DEBUG) VERSION=$(VERSION) $(ROOT_DIR)/hack/build_deb.sh
 .PHONY: generate

--- a/hack/build_deb.sh
+++ b/hack/build_deb.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+if [ "$DEBUG" = "true" ]; then
+    set -ex
+    export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+fi
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+export PKG_CONFIG_PATH=/usr/lib/pkgconfig/:/usr/local/lib/pkgconfig/:/usr/local/share/pkgconfig
+path=$(mktemp -d)
+dest=$path/opt/yunion/bin
+
+if [ -z "$ROOT_DIR" ]; then
+	pushd $(dirname $(readlink -f "$BASH_SOURCE")) > /dev/null
+	ROOT_DIR=$(cd .. && pwd)
+	popd > /dev/null
+fi
+
+PACKAGE=yunion-ocadm
+BUILDROOT=$path
+if [ -z "$VERSION"  ]; then
+    TAG=$(git describe --abbrev=0 --tags || echo 000000)
+    VERSION=${TAG/\//-}
+    VERSION=${VERSION/v/}
+fi
+
+RELEASE=`date +"%y%m%d%H"`
+FULL_VERSION=$VERSION-$RELEASE
+
+rm -rf $BUILDROOT
+mkdir -p $BUILDROOT
+mkdir -p $BUILDROOT/DEBIAN
+mkdir -p $dest
+
+case $(uname -m) in
+	x86_64)
+		CURRENT_ARCH=amd64
+		;;
+	aarch64)
+		CURRENT_ARCH=arm64
+		;;
+esac
+
+function build_ocadm() {
+	# cd deps
+	# (sh libusb_install)
+	# (sh usbredir_install)
+	# (sh spice_protocol_install)
+	# (sh spice_install)
+	# cd ..
+	make -j $(grep -c ^processor /proc/cpuinfo)
+    make build
+    find $path
+    cp -fv _output/bin/ocadm $dest
+}
+
+function build_deb() {
+echo "Package: yunion-ocadm
+Version: $FULL_VERSION
+Section: base
+Priority: optional
+Architecture: $CURRENT_ARCH
+Maintainer: zhangdongliang@yunionyun.com
+Description: Yunion ocadm
+ Yunion-ocadm $VERSION build by yunion.
+" > $BUILDROOT/DEBIAN/control
+chmod 0755 $BUILDROOT/DEBIAN/control
+dpkg-deb --build $BUILDROOT
+ls -lah $BUILDROOT.deb
+mv -fv $BUILDROOT.deb yunion-ocadm-$FULL_VERSION.deb
+rm -rfv $BUILDROOT
+}
+
+build_ocadm && build_deb

--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -34,11 +34,10 @@ const (
 	DefaultKeepalivedVersionTag    = "v2.0.24"
 	// mirror of kiwigrid/k8s-sidecar:0.1.20
 	K8sSidecar               = "k8s-sidecar"
-	DefaultK8sSidecarVersion = "0.1.20"
+	DefaultK8sSidecarVersion = "0.1.275"
 	Busybox                  = "busybox"
 	BusyboxVersion           = "1.28.0-glibc"
-	MetricsServerAmd64       = "metrics-server-amd64"
-	MetricsServerArm64       = "metrics-server-arm64"
+	MetricsServer            = "metrics-server"
 	MetricsServerVersion     = "v0.3.6"
 
 	EndpointTypeInternal = "internal"

--- a/pkg/phases/addons/metricsserver/metricsserver.go
+++ b/pkg/phases/addons/metricsserver/metricsserver.go
@@ -18,12 +18,8 @@ type MetricsServerConfig struct {
 func NewMetricsServerConfig(cfg *kubeadmapi.ClusterConfiguration) addons.Configer {
 	arch := runtime.GOARCH
 	repo := cfg.ImageRepository
-	metricsServer := constants.MetricsServerAmd64
-	if arch == "arm64" {
-		metricsServer = constants.MetricsServerArm64
-	}
 	config := MetricsServerConfig{
-		Image: images.GetGenericImage(repo, metricsServer, constants.MetricsServerVersion),
+		Image: images.GetGenericImage(repo, constants.MetricsServer, constants.MetricsServerVersion),
 		Arch:  arch,
 	}
 	return config


### PR DESCRIPTION
Cherry pick of #161 on release/3.6.

#161: feat(build): 增加arm 下编译 ocadm deb 的步骤(make deb)； 统一跨平台metrics-server 的 tag 名称；升级 k8s-sidecar 到 0.1.275