### PR TITLE
Automated cherry pick of #169: feat(keepalived,ha): 新增 keepalived_interface 变量支持,以便在安装高可用多网卡情况下支持非默认网卡绑定 vip

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -31,7 +31,7 @@ const (
 	DefaultPromtailVersion         = DefaultLokiVersion
 	Grafana                        = "grafana"
 	DefaultGrafanaVersion          = "6.5.2"
-	DefaultKeepalivedVersionTag    = "v2.0.24"
+	DefaultKeepalivedVersionTag    = "v2.0.25"
 	// mirror of kiwigrid/k8s-sidecar:0.1.20
 	K8sSidecar               = "k8s-sidecar"
 	DefaultK8sSidecarVersion = "0.1.20"

--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/lithammer/dedent"
@@ -84,6 +85,7 @@ type joinOptions struct {
 	baremetalNode         bool
 	esxiNode              bool
 	upgradeFromV2         bool
+	hostInterface         string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -108,6 +110,7 @@ type joinData struct {
 	glanceNode            bool
 	baremetalNode         bool
 	esxiNode              bool
+	hostInterface         string
 }
 
 // NewCmdJoin returns "ocadm join" command
@@ -406,6 +409,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		nodeIP:                opt.nodeIP,
 		highAvailabilityVIP:   opt.highAvailabilityVIP,
 		keepalivedVersionTag:  opt.keepalivedVersionTag,
+		hostInterface:         strings.Split(opt.hostCfg.Networks[0], "/")[0],
 	}, nil
 }
 
@@ -417,6 +421,11 @@ func (j *joinData) GetHighAvailabilityVIP() string {
 // GetKeepalivedVersionTag return the keepalivedVersionTag
 func (j *joinData) GetKeepalivedVersionTag() string {
 	return j.keepalivedVersionTag
+}
+
+// GetHostInterface return the hostInterface
+func (j *joinData) GetHostInterface() string {
+	return j.hostInterface
 }
 
 // EnableHostAgent return is enable host agent

--- a/pkg/phases/join/data.go
+++ b/pkg/phases/join/data.go
@@ -15,4 +15,5 @@ type JoinData interface {
 	GetHighAvailabilityVIP() string
 	GetKeepalivedVersionTag() string
 	GetNodeIP() string
+	GetHostInterface() string
 }


### PR DESCRIPTION
Cherry pick of #169 on release/3.5.

#169: feat(keepalived,ha): 新增 keepalived_interface 变量支持,以便在安装高可用多网卡情况下支持非默认网卡绑定 vip