### PR TITLE
Automated cherry pick of #173: fix(keepalived): 解决 高可用架构部署的默认网卡传递参数问题

### DIFF
--- a/pkg/cmd/join.go
+++ b/pkg/cmd/join.go
@@ -400,6 +400,11 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		}
 	}
 
+	hostInterface := ""
+	if len(opt.hostCfg.Networks) >= 1 && strings.Contains(opt.hostCfg.Networks[0], "/") {
+		hostInterface = strings.Split(opt.hostCfg.Networks[0], "/")[0]
+	}
+
 	return &joinData{
 		cfg:                   cfg,
 		tlsBootstrapCfg:       tlsBootstrapCfg,
@@ -409,7 +414,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		nodeIP:                opt.nodeIP,
 		highAvailabilityVIP:   opt.highAvailabilityVIP,
 		keepalivedVersionTag:  opt.keepalivedVersionTag,
-		hostInterface:         strings.Split(opt.hostCfg.Networks[0], "/")[0],
+		hostInterface:         hostInterface,
 	}, nil
 }
 


### PR DESCRIPTION
Cherry pick of #173 on release/3.4.

#173: fix(keepalived): 解决 高可用架构部署的默认网卡传递参数问题