### PR TITLE
Automated cherry pick of #179: fix(k8s,keepalived): 解决 k8s 高可用集群在部署时无法获取 nodeip 的问题

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -699,7 +699,13 @@ func (d *initData) OperatorVersion() string {
 
 // GetNodeIP returns current node ip for init mode
 func (d *initData) GetNodeIP() string {
-	return d.nodeIP
+	if len(d.nodeIP) > 0 {
+		return d.nodeIP
+	}
+	if strings.HasPrefix(d.addonCalicoIpAutodetectionMethod, "can-reach=") {
+		return strings.Replace(d.addonCalicoIpAutodetectionMethod, "can-reach=", "", -1)
+	}
+	return ""
 }
 
 func printJoinCommand(out io.Writer, adminKubeConfigPath, token string, i *initData) error {

--- a/pkg/phases/addons/keepalived/keepalived.go
+++ b/pkg/phases/addons/keepalived/keepalived.go
@@ -100,6 +100,11 @@ func runKeepalivedPhaseLocal() func(c workflow.RunData) error {
 			fmt.Println("vip is empty. no need to install keepalived.")
 			return nil
 		}
+		if len(nodeIP) == 0 {
+			msg := "error! got empty node ip for k8s HA."
+			fmt.Println(msg)
+			return fmt.Errorf(msg)
+		}
 		if len(keepalivedVersionTag) == 0 {
 			fmt.Println("Keepalived version tag is empty! using default option: ", constants.DefaultKeepalivedVersionTag)
 			keepalivedVersionTag = constants.DefaultKeepalivedVersionTag


### PR DESCRIPTION
Cherry pick of #179 on release/3.7.

#179: fix(k8s,keepalived): 解决 k8s 高可用集群在部署时无法获取 nodeip 的问题