### PR TITLE
Automated cherry pick of #215: feat: set kube-controller-manager and calico node ip pool block size

### DIFF
--- a/pkg/options/constant.go
+++ b/pkg/options/constant.go
@@ -30,6 +30,8 @@ const (
 	NodeIP                             = "node-ip"
 	AddonCalicoIpAutodetectionMethod   = "addon-calico-ip-autodetection-method"
 	AddonCalicoiFelixChaininsertmode   = "addon-calico-felix-chaininsertmode"
+	NodeCIDRMaskSize                   = "node-cidr-mask-size"
+	AddonCalicoIPV4BlockSize           = "addon-calico-ipv4-block-size"
 	HighAvailabilityVIP                = "high-availability-vip"
 	KeepalivedVersionTag               = "keepalived-version-tag"
 	LonghornDataPath                   = "longhorn-data-path"

--- a/pkg/phases/addons/calico/calico.go
+++ b/pkg/phases/addons/calico/calico.go
@@ -18,11 +18,15 @@ type CNICalicoConfig struct {
 	ClusterCIDR           string
 	IPAutodetectionMethod string
 	FelixChaininsertmode  string
+	IPV4PoolBlockSize     int
 }
 
-func NewCalicoConfig(cfg *kubeadmapi.ClusterConfiguration, IPAutodetectionMethod, FelixChaininsertmode string) addons.Configer {
+func NewCalicoConfig(cfg *kubeadmapi.ClusterConfiguration, IPAutodetectionMethod, FelixChaininsertmode string, ipv4PoolBlockSize int) addons.Configer {
 	if len(FelixChaininsertmode) == 0 {
 		FelixChaininsertmode = constants.DefaultCalicoFelixChaininsertmode
+	}
+	if ipv4PoolBlockSize < 0 {
+		ipv4PoolBlockSize = 26
 	}
 	repo := cfg.ImageRepository
 	config := &CNICalicoConfig{
@@ -32,6 +36,7 @@ func NewCalicoConfig(cfg *kubeadmapi.ClusterConfiguration, IPAutodetectionMethod
 		ClusterCIDR:           cfg.Networking.PodSubnet,
 		IPAutodetectionMethod: IPAutodetectionMethod,
 		FelixChaininsertmode:  FelixChaininsertmode,
+		IPV4PoolBlockSize:     ipv4PoolBlockSize,
 	}
 	return config
 }

--- a/pkg/phases/addons/calico/template.go
+++ b/pkg/phases/addons/calico/template.go
@@ -616,6 +616,8 @@ spec:
             # no effect. This should fall within --cluster-cidr.
             - name: CALICO_IPV4POOL_CIDR
               value: "{{.ClusterCIDR}}"
+            - name: CALICO_IPV4POOL_BLOCK_SIZE
+              value: "{{.IPV4PoolBlockSize}}"
             # Disable file logging so 'kubectl logs' works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/pkg/phases/init/addons.go
+++ b/pkg/phases/init/addons.go
@@ -91,6 +91,7 @@ func NewOCAddonPhase() workflow.Phase {
 			options.PrintAddonYaml,
 			options.AddonCalicoIpAutodetectionMethod,
 			options.AddonCalicoiFelixChaininsertmode,
+			options.AddonCalicoIPV4BlockSize,
 			options.OperatorVersion,
 		},
 		Phases: []workflow.Phase{
@@ -140,7 +141,8 @@ func kubectlApplyAddon(c workflow.RunData, newF func(*kubeadmapi.ClusterConfigur
 
 func runCalicoAddon(c workflow.RunData) error {
 	return kubectlApplyAddon(c, func(cfg *kubeadmapi.ClusterConfiguration) addons.Configer {
-		return calicoaddon.NewCalicoConfig(cfg, c.(InitData).AddonCalicoIpAutodetectionMethod(), c.(InitData).AddonCalicoiFelixChaininsertmode())
+		d := c.(InitData)
+		return calicoaddon.NewCalicoConfig(cfg, d.AddonCalicoIpAutodetectionMethod(), d.AddonCalicoiFelixChaininsertmode(), d.AddonCalicoIPV4PoolBlockSize())
 	})
 }
 
@@ -189,6 +191,8 @@ func getAddonPhaseFlags(name string) []string {
 			options.NetworkingPodSubnet,
 			options.OperatorVersion,
 			options.AddonCalicoIpAutodetectionMethod,
+			options.AddonCalicoiFelixChaininsertmode,
+			options.AddonCalicoIPV4BlockSize,
 		)
 	}
 	if name == "onecloud-operator" {

--- a/pkg/phases/init/data.go
+++ b/pkg/phases/init/data.go
@@ -25,6 +25,7 @@ type InitData interface {
 	PrintAddonYaml() bool
 	AddonCalicoIpAutodetectionMethod() string
 	AddonCalicoiFelixChaininsertmode() string
+	AddonCalicoIPV4PoolBlockSize() int
 	GetHighAvailabilityVIP() string
 	GetKeepalivedVersionTag() string
 	GetNodeIP() string


### PR DESCRIPTION
Cherry pick of #215 on release/3.9.

#215: feat: set kube-controller-manager and calico node ip pool block size