### PR TITLE
Automated cherry pick of #217: fix: disable trafik TLSv1.0 and TLSv1.1

### DIFF
--- a/pkg/phases/addons/traefik/template.go
+++ b/pkg/phases/addons/traefik/template.go
@@ -70,6 +70,15 @@ data:
       [entryPoints.https]
         address = ":443"
         [entryPoints.https.tls]
+          minVersion = "VersionTLS12"
+          cipherSuites = [
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+          ]
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Cherry pick of #217 on release/3.8.

#217: fix: disable trafik TLSv1.0 and TLSv1.1