### PR TITLE
feat:(build,rpm) 优先使用打包环境的fpm而非docker

### DIFF
--- a/hack/make-package.sh
+++ b/hack/make-package.sh
@@ -16,5 +16,8 @@ GIT_VERSION=$TAG GIT_BRANCH=tags/$TAG make
 mkdir -p $YUNION_BIN
 
 cp -a "$OUTPUT_DIR/bin/ocadm" "$YUNION_BIN"
-
-docker run --rm -v "$(pwd):/src/" cdrx/fpm-centos:7 fpm  -n yunion-ocadm -v "${TAG#v}" -s dir -t rpm  -C "_output/pkg"
+if [ -x /usr/bin/fpm ] ; then
+    fpm  -n yunion-ocadm -v "${TAG#v}" -s dir -t rpm  -C "_output/pkg"
+else
+    docker run --rm -v "$(pwd):/src/" cdrx/fpm-centos:7 fpm  -n yunion-ocadm -v "${TAG#v}" -s dir -t rpm  -C "_output/pkg"
+fi


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 优先使用打包环境的fpm而非docker

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10