### PR TITLE
Automated cherry pick of #237: fix(operator): preferred scheduling to onecloud controller

### DIFF
--- a/pkg/phases/addons/onecloudoperator/template.go
+++ b/pkg/phases/addons/onecloudoperator/template.go
@@ -53,6 +53,16 @@ spec:
       labels:
         k8s-app: onecloud-operator
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: onecloud.yunion.io/controller
+                operator: In
+                values:
+                - enable
       serviceAccount: onecloud-operator
       priorityClassName: onecloud-operator-critical
       tolerations:


### PR DESCRIPTION
Cherry pick of #237 on release/3.8.

#237: fix(operator): preferred scheduling to onecloud controller