### PR TITLE
Automated cherry pick of #271: fix: update ocadm version to v3.27.0

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	CalicoKubeControllers             = "calico-kube-controllers"
 	CalicoNode                        = "calico-node"
 	CalicoCNI                         = "calico-cni"
-	DefaultCalicoVersion              = "v3.12.1"
+	DefaultCalicoVersion              = "v3.27.0"
 	DefaultCalicoFelixChaininsertmode = "Append"
 	Loki                              = "loki"
 	DefaultLokiVersion                = "v1.2.0"


### PR DESCRIPTION
Cherry pick of #271 on release/3.12.

#271: fix: update ocadm version to v3.27.0