### PR TITLE
Automated cherry pick of #279: fix: avoid keepalived router id to be 0

### DIFF
--- a/pkg/phases/addons/keepalived/keepalived.go
+++ b/pkg/phases/addons/keepalived/keepalived.go
@@ -172,6 +172,10 @@ func GetKeepalivedPodSpec(vip, keepalivedVersionTag, role, nodeIP, hostInterface
 	}
 
 	vid = vid % 255
+	if vid == 0 {
+		// 防止 vid 为0，比如当 vip 为：172.16.210.250
+		vid = 100
+	}
 	svid := fmt.Sprintf("%d", vid)
 
 	return staticpodutil.ComponentPod(v1.Container{


### PR DESCRIPTION
Cherry pick of #279 on master.

#279: fix: avoid keepalived router id to be 0